### PR TITLE
[7.x] updated .gitignore file (27686eca)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Backports the following commits to 7.x:
 - updated .gitignore file (27686eca)