### PR TITLE
[7.7] updated .gitignore file (27686eca)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Backports the following commits to 7.7:
 - updated .gitignore file (27686eca)